### PR TITLE
Update hashpp.h to fix compilation bug

### DIFF
--- a/include/hashpp.h
+++ b/include/hashpp.h
@@ -62,6 +62,7 @@
 	PU64B(((l) << 3), (y), (z) + 8);           \
 } while(0)					   \
 
+#include <cstring>
 #include <iostream>
 #include <fstream>
 #include <filesystem>


### PR DESCRIPTION
Fix "memset was not declared" error by include cstring header.
![image](https://github.com/D7EAD/HashPlusPlus/assets/19610256/1930b4f2-5c21-41e6-bc4f-9dea45610915)
